### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/hacs_validate.yaml
+++ b/.github/workflows/hacs_validate.yaml
@@ -1,5 +1,8 @@
 name: HACS Validation
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/miggi92/hass-handball.net/security/code-scanning/2](https://github.com/miggi92/hass-handball.net/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. Based on the provided code, the workflow uses the `hacs/action@main` action for validation, which likely only requires read access to the repository contents. Therefore, the minimal permissions block should specify `contents: read`. This block can be added at the root level of the workflow to apply to all jobs, or specifically to the `hacs` job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
