### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -1,5 +1,8 @@
 name: hassfest Validation
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/miggi92/hass-handball.net/security/code-scanning/1](https://github.com/miggi92/hass-handball.net/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow performs validation tasks, it likely only requires read access to repository contents. We will add `permissions: contents: read` at the root level of the workflow to apply this restriction to all jobs. This ensures the `GITHUB_TOKEN` has the minimum necessary permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
